### PR TITLE
fix: install instruction for the package

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,10 @@
 Go SDK for supporting structured logging in applications
 
 ## Installation
-`go install github.com/interviewstreet/logging-go@latest`
+```console
+go get github.com/interviewstreet/logging-go@latest
+go mod tidy
+```
 
 ## Usage
 ```go


### PR DESCRIPTION
`go install` installs the package but ignores the local `go.mod` file, whereas `go get` updates the `go.mod` file to include the package.

This PR fixes the install instructions. Assuming this library is intended to be used as a dependency for other packages, and with no `main` package it is clear.

Signed-off-by: Aaqa Ishtyaq <aaqa@hackerrank.com>